### PR TITLE
Refactor deck persistence to use injected context

### DIFF
--- a/ClashOps/ClashOps/CategoryBuilderView.swift
+++ b/ClashOps/ClashOps/CategoryBuilderView.swift
@@ -75,13 +75,12 @@ struct CategoryBuilderView: View {
                             popupController.showPopup = true
                         }
                         if categoryIcon != "" {
-                            let context = PersistenceController.shared.container.viewContext
-                            let category = FavCat(context: context)
+                            let category = FavCat(context: viewContext)
                             category.name = newName
                             category.icon = categoryIcon
                             category.color = selectedColor
                             do {
-                                try context.save()
+                                try viewContext.save()
                             } catch {
                                 print("Error deleting item: \(error.localizedDescription)")
                             }

--- a/ClashOps/ClashOps/CategoryDecksView.swift
+++ b/ClashOps/ClashOps/CategoryDecksView.swift
@@ -159,7 +159,7 @@ struct CategoryDecksView: View {
                                                                 deleteDeck(deck: deck)
                                                                 updateFavs.updateVar -= 1
                                                                 do {
-                                                                    try context.save()
+                                                                    try viewContext.save()
                                                                     print("saved to Core Data")
                                                                 } catch {
                                                                     print("Error saving: \(error.localizedDescription)")

--- a/ClashOps/ClashOps/DeckBuilderView.swift
+++ b/ClashOps/ClashOps/DeckBuilderView.swift
@@ -36,6 +36,10 @@ struct DeckBuilderView: View {
         Array(externalData.cards).sorted(by: sortMode.comparator)
     }
 
+    private var deckPersistenceService: DeckPersistenceService {
+        DeckPersistenceService(viewContext: viewContext)
+    }
+
     var sortLabel: String {
         "Sorted by \(sortMode.label)"
     }
@@ -104,14 +108,12 @@ struct DeckBuilderView: View {
         }
         guard includedCards.count == 8 else { return }
 
-        let cardList = includedCards.map { nameToApi(name: $0) }
-        let fav = FavDeck(context: viewContext)
-        fav.name = newName
-        fav.cards = cardList.joined(separator: ",")
-        fav.category = selectedCategory
-
         do {
-            try viewContext.save()
+            try deckPersistenceService.saveDeck(
+                name: newName,
+                cards: includedCards.map { nameToApi(name: $0) },
+                category: selectedCategory
+            )
             print("saved to Core Data")
         } catch {
             print("Error saving: \(error.localizedDescription)")

--- a/ClashOps/ClashOps/DeckCatalogView.swift
+++ b/ClashOps/ClashOps/DeckCatalogView.swift
@@ -121,12 +121,12 @@ struct DeckCatalogView: View {
                                                                 popupController.showPopup = true
                                                             }
                                                             let cardsCSV = deck.cards.joined(separator: ",")
-                                                            let fav = FavDeck(context: context)
+                                                            let fav = FavDeck(context: viewContext)
                                                             fav.name = "My Favourite Deck"
                                                             fav.cards = cardsCSV
                                                             fav.category = "none"
                                                             do {
-                                                                try context.save()
+                                                                try viewContext.save()
                                                                 print("saved to Core Data")
                                                             } catch {
                                                                 print("Error saving: \(error.localizedDescription)")
@@ -217,12 +217,12 @@ struct DeckCatalogView: View {
                                                         popupController.showPopup = true
                                                     }
                                                     let cardsCSV = deck.cards.joined(separator: ",")
-                                                    let fav = FavDeck(context: context)
+                                                    let fav = FavDeck(context: viewContext)
                                                     fav.name = "My Favourite Deck"
                                                     fav.cards = cardsCSV
                                                     fav.category = "none"
                                                     do {
-                                                        try context.save()
+                                                        try viewContext.save()
                                                         print("saved to Core Data")
                                                     } catch {
                                                         print("Error saving: \(error.localizedDescription)")

--- a/ClashOps/ClashOps/DeckEditorView.swift
+++ b/ClashOps/ClashOps/DeckEditorView.swift
@@ -36,6 +36,10 @@ struct DeckEditorView: View {
         Array(externalData.cards).sorted(by: sortMode.comparator)
     }
 
+    private var deckPersistenceService: DeckPersistenceService {
+        DeckPersistenceService(viewContext: viewContext)
+    }
+
     var sortLabel: String {
         "Sorted by \(sortMode.label)"
     }
@@ -114,8 +118,7 @@ struct DeckEditorView: View {
                                     print("🔎 \(key): \(String(describing: value))")
                                 }
                                 deckToEdit.category = selectedCategory
-                                let context = PersistenceController.shared.container.viewContext
-                                try context.save()  // ✅ save the actual context
+                                try deckPersistenceService.saveContext()
                                 updateFavs.updateVar += 1
                                 dismiss()
                             } catch {

--- a/ClashOps/ClashOps/DeckPersistenceService.swift
+++ b/ClashOps/ClashOps/DeckPersistenceService.swift
@@ -1,0 +1,30 @@
+import Foundation
+import CoreData
+
+final class DeckPersistenceService {
+    private let viewContext: NSManagedObjectContext
+
+    init(viewContext: NSManagedObjectContext) {
+        self.viewContext = viewContext
+    }
+
+    /// Creates and saves a new deck.
+    /// - Parameters:
+    ///   - name: Deck name to persist.
+    ///   - cards: Array of card identifiers.
+    ///   - category: Category name to associate with the deck.
+    func saveDeck(name: String, cards: [String], category: String) throws {
+        let deck = FavDeck(context: viewContext)
+        deck.name = name
+        deck.cards = cards.joined(separator: ",")
+        deck.category = category
+        try saveContext()
+    }
+
+    /// Persists any pending changes if needed.
+    func saveContext() throws {
+        if viewContext.hasChanges {
+            try viewContext.save()
+        }
+    }
+}

--- a/ClashOps/ClashOps/FavouriteDecksView.swift
+++ b/ClashOps/ClashOps/FavouriteDecksView.swift
@@ -22,6 +22,7 @@ struct FavouriteDecksView: View {
     @ObservedObject var updateFavs: updateFavourites
     @ObservedObject var viewModel: CardSelectionViewModel
     @EnvironmentObject var popupController: PopupController
+    @Environment(\.managedObjectContext) private var viewContext
     
     var categoryNames: [String] {
         fetchCategories().compactMap { $0.name }
@@ -160,7 +161,7 @@ struct FavouriteDecksView: View {
                                                                             deleteDeck(deck: deck)
                                                                             updateFavs.updateVar -= 1
                                                                             do {
-                                                                                try context.save()
+                                                                                try viewContext.save()
                                                                                 print("saved to Core Data")
                                                                             } catch {
                                                                                 print("Error saving: \(error.localizedDescription)")
@@ -337,13 +338,13 @@ struct FavouriteDecksView: View {
                                                                             popupController.message = "Deck removed from favourites"
                                                                             popupController.showPopup = true
                                                                         }
-                                                                        deleteDeck(deck: deck)
-                                                                        updateFavs.updateVar -= 1
-                                                                        do {
-                                                                            try context.save()
-                                                                            print("saved to Core Data")
-                                                                        } catch {
-                                                                            print("Error saving: \(error.localizedDescription)")
+                                                                            deleteDeck(deck: deck)
+                                                                            updateFavs.updateVar -= 1
+                                                                            do {
+                                                                                try viewContext.save()
+                                                                                print("saved to Core Data")
+                                                                            } catch {
+                                                                                print("Error saving: \(error.localizedDescription)")
                                                                         }
                                                                     }) {
                                                                         HStack {


### PR DESCRIPTION
## Summary
- add a reusable DeckPersistenceService to encapsulate deck saving logic
- update deck add/edit flows to rely on the injected managed object context
- align category and deck favourite actions to save with the environment context

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69349dfb54348328aedd97646b1e3bba)