### PR TITLE
Fix DeckBuilder TextField prompt styling

### DIFF
--- a/ClashOps/ClashOps/DeckBuilderView.swift
+++ b/ClashOps/ClashOps/DeckBuilderView.swift
@@ -60,8 +60,7 @@ struct DeckBuilderView: View {
                 .padding(.bottom, 16)
 
                 TextField("", text: $newName, prompt:
-                    Text("My Favourite Deck")
-                        .goldForeground())
+                    Text("My Favourite Deck"))
                     .background(Color.black.opacity(0.2))
                     .goldForeground()
                     .frame(width: 200)


### PR DESCRIPTION
## Summary
- adjust the DeckBuilder TextField prompt to use a plain Text value while keeping styling on the field

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934cb9ec0e48328bed7c16fec5afa21)