### PR TITLE
Consolidate shared grid layouts

### DIFF
--- a/ClashOps/ClashOps/CategoryBuilderView.swift
+++ b/ClashOps/ClashOps/CategoryBuilderView.swift
@@ -22,13 +22,7 @@ struct CategoryBuilderView: View {
     @ObservedObject var updateFavs: updateFavourites
     @EnvironmentObject var popupController: PopupController
     @Environment(\.managedObjectContext) private var viewContext
-    let columns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
-        ]
+    let columns = fiveColumnGrid
         
     var body: some View {
         ZStack {

--- a/ClashOps/ClashOps/CategoryDecksView.swift
+++ b/ClashOps/ClashOps/CategoryDecksView.swift
@@ -12,12 +12,7 @@ import CoreData
 struct CategoryDecksView: View {
     @Environment(\.dismiss) private var dismiss
     
-    let columns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()) 
-    ]
+    let columns = fourColumnGrid
     
     @ObservedObject var externalData: ExternalData
     @ObservedObject var updateFavs: updateFavourites

--- a/ClashOps/ClashOps/CategoryEditorView.swift
+++ b/ClashOps/ClashOps/CategoryEditorView.swift
@@ -23,13 +23,7 @@ struct CategoryEditorView: View {
     @ObservedObject var categoryToEdit: FavCat
     @EnvironmentObject var popupController: PopupController
     @Environment(\.managedObjectContext) private var viewContext
-    let columns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
-        ]
+    let columns = fiveColumnGrid
         
     var body: some View {
         ZStack {

--- a/ClashOps/ClashOps/DeckBuilderView.swift
+++ b/ClashOps/ClashOps/DeckBuilderView.swift
@@ -58,25 +58,9 @@ struct DeckBuilderView: View {
         return label
     }
     
-    let deckColumns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
-    ]
-    
-    let cardColumns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
-    ]
+    let deckColumns = eightColumnGrid
+
+    let cardColumns = sixColumnGrid
     
     //MARK: Body
     var body: some View {

--- a/ClashOps/ClashOps/DeckCatalogView.swift
+++ b/ClashOps/ClashOps/DeckCatalogView.swift
@@ -5,13 +5,7 @@ import CoreData
 struct DeckCatalogView: View {
     
     //MARK: Declarations
-    let columns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
-        
-    ]
+    let columns = fourColumnGrid
     
     @ObservedObject var externalData: ExternalData
     @ObservedObject var viewModel: CardSelectionViewModel

--- a/ClashOps/ClashOps/DeckEditorView.swift
+++ b/ClashOps/ClashOps/DeckEditorView.swift
@@ -62,25 +62,9 @@ struct DeckEditorView: View {
         return label
     }
     
-    let deckColumns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
-    ]
-    
-    let cardColumns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
-    ]
+    let deckColumns = eightColumnGrid
+
+    let cardColumns = sixColumnGrid
     
 
     

--- a/ClashOps/ClashOps/FavouriteDecksView.swift
+++ b/ClashOps/ClashOps/FavouriteDecksView.swift
@@ -26,12 +26,7 @@ struct FavouriteDecksView: View {
     var categoryNames: [String] {
         fetchCategories().compactMap { $0.name }
     }
-    let columns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
-    ]
+    let columns = fourColumnGrid
     
     var body: some View {
 

--- a/ClashOps/ClashOps/FeaturedDecksView.swift
+++ b/ClashOps/ClashOps/FeaturedDecksView.swift
@@ -17,12 +17,7 @@ struct FeaturedDecksView: View {
     let name: String
     let filterOptions: [String]
     @State var removeFromFavs: ObjectIdentifier? = nil
-    let columns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
-    ]
+    let columns = fourColumnGrid
     
     @ObservedObject var updateFavs: updateFavourites
     @Environment(\.managedObjectContext) private var viewContext

--- a/ClashOps/ClashOps/FilterCardsView.swift
+++ b/ClashOps/ClashOps/FilterCardsView.swift
@@ -22,14 +22,7 @@ struct FilterCardsView: View {
     @Binding var includedCardsName: Set<String>
     @Binding var discludedCardsName: Set<String>
  //   @ObservedObject var path: pathClass
-    let columns = [
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
-
-    ]
+    let columns = fiveColumnGrid
     
     var sortedCards: [(key: String, value: Mapping)] {
         var base = Array(externalData.cards).sorted { $0.key < $1.key }

--- a/ClashOps/ClashOps/Models.swift
+++ b/ClashOps/ClashOps/Models.swift
@@ -17,6 +17,12 @@ let optimizeURL: String = (NSDictionary(contentsOfFile: Bundle.main.path(forReso
 let analyzeURL: String = (NSDictionary(contentsOfFile: Bundle.main.path(forResource: "Config", ofType: "plist") ?? "")?["ANALYZE_URL"] as? String) ?? ""
 let createReportURL: String = (NSDictionary(contentsOfFile: Bundle.main.path(forResource: "Config", ofType: "plist") ?? "")?["CREATE_REPORT_URL"] as? String) ?? ""
 
+// Grid layouts
+let fourColumnGrid: [GridItem] = Array(repeating: GridItem(.flexible()), count: 4)
+let fiveColumnGrid: [GridItem] = Array(repeating: GridItem(.flexible()), count: 5)
+let sixColumnGrid: [GridItem] = Array(repeating: GridItem(.flexible()), count: 6)
+let eightColumnGrid: [GridItem] = Array(repeating: GridItem(.flexible()), count: 8)
+
 
 struct createReportRequest: Codable {
     let deck: String


### PR DESCRIPTION
## Summary
- add shared grid layout constants in `Models.swift` for reuse across views
- update deck and card grid views to reference the shared layouts and remove duplicate column definitions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934db55bd04832895f8c463bf947089)