### PR TITLE
Add hero image preload for mid deck slots

### DIFF
--- a/ClashOps/ClashOps/DeckBuilderView.swift
+++ b/ClashOps/ClashOps/DeckBuilderView.swift
@@ -203,9 +203,17 @@ struct DeckBuilderView: View {
                         ForEach(Array(includedCards.enumerated()), id: \.element) { index, card in
                             let cardIndex = index + 1
                             let ev1UrlString = "https://cdns3.royaleapi.com/cdn-cgi/image/w=150,h=180,format=auto/static/img/cards/v6-aa179c9e/\(card)-ev1.png"
+                            let heroUrlString = "https://cdns3.royaleapi.com/cdn-cgi/image/w=150,h=180,format=auto/static/img/cards/v6-aa179c9e/\(card)-hero.png"
                             let fallbackUrlString = "https://cdns3.royaleapi.com/cdn-cgi/image/w=150,h=180,format=auto/static/img/cards/v6-aa179c9e/\(card).png"
-                            
-                            let primaryUrl = (cardIndex <= 2) ? URL(string: ev1UrlString) : URL(string: fallbackUrlString)
+
+                            let primaryUrl: URL?
+                            if cardIndex <= 2 {
+                                primaryUrl = URL(string: ev1UrlString)
+                            } else if cardIndex <= 4 {
+                                primaryUrl = URL(string: heroUrlString)
+                            } else {
+                                primaryUrl = URL(string: fallbackUrlString)
+                            }
                             let fallbackUrl = URL(string: fallbackUrlString)
                             
                             if let url = primaryUrl {

--- a/ClashOps/ClashOps/DeckEditorView.swift
+++ b/ClashOps/ClashOps/DeckEditorView.swift
@@ -226,9 +226,17 @@ struct DeckEditorView: View {
                             let cardIndex = index + 1
                             
                             let ev1UrlString = "https://cdns3.royaleapi.com/cdn-cgi/image/w=150,h=180,format=auto/static/img/cards/v6-aa179c9e/\(apiToName(api: card))-ev1.png"
+                            let heroUrlString = "https://cdns3.royaleapi.com/cdn-cgi/image/w=150,h=180,format=auto/static/img/cards/v6-aa179c9e/\(apiToName(api: card))-hero.png"
                             let fallbackUrlString = "https://cdns3.royaleapi.com/cdn-cgi/image/w=150,h=180,format=auto/static/img/cards/v6-aa179c9e/\(apiToName(api: card)).png"
-                            
-                            let primaryUrl = (cardIndex <= 2) ? URL(string: ev1UrlString) : URL(string: fallbackUrlString)
+
+                            let primaryUrl: URL?
+                            if cardIndex <= 2 {
+                                primaryUrl = URL(string: ev1UrlString)
+                            } else if cardIndex <= 4 {
+                                primaryUrl = URL(string: heroUrlString)
+                            } else {
+                                primaryUrl = URL(string: fallbackUrlString)
+                            }
                             let fallbackUrl = URL(string: fallbackUrlString)
                             
                             if let url = primaryUrl {

--- a/ClashOps/ClashOps/Models.swift
+++ b/ClashOps/ClashOps/Models.swift
@@ -1912,8 +1912,16 @@ func deckGrid(deck: Deck, cardMap: [String: Mapping], columns: [GridItem]) -> so
                     .frame(height: 120)
             } else if let royaleapiName = cardMap[cardName]?.apiName {
                 let ev1UrlString = "https://cdns3.royaleapi.com/cdn-cgi/image/w=150,h=180,format=auto/static/img/cards/v6-aa179c9e/\(royaleapiName)-ev1.png"
+                let heroUrlString = "https://cdns3.royaleapi.com/cdn-cgi/image/w=150,h=180,format=auto/static/img/cards/v6-aa179c9e/\(royaleapiName)-hero.png"
                 let fallbackUrlString = "https://cdns3.royaleapi.com/cdn-cgi/image/w=150,h=180,format=auto/static/img/cards/v6-aa179c9e/\(royaleapiName).png"
-                let primaryUrl = (cardIndex <= 2) ? URL(string: ev1UrlString) : URL(string: fallbackUrlString)
+                let primaryUrl: URL?
+                if cardIndex <= 2 {
+                    primaryUrl = URL(string: ev1UrlString)
+                } else if cardIndex <= 4 {
+                    primaryUrl = URL(string: heroUrlString)
+                } else {
+                    primaryUrl = URL(string: fallbackUrlString)
+                }
                 let fallbackUrl = URL(string: fallbackUrlString)
 
                 if let url = primaryUrl {


### PR DESCRIPTION
## Summary
- attempt hero artwork for the 3rd and 4th deck cards before default assets
- keep evolution art priority for the first two cards across builder, editor, and deck grid views

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934e90ea6d883288d2f7d750aedbba8)